### PR TITLE
fix building on Windows issue with SDL_main

### DIFF
--- a/sdl2-image.cabal
+++ b/sdl2-image.cabal
@@ -42,6 +42,9 @@ library
   default-language:
     Haskell2010
 
+  if os(windows)
+    cpp-options: -D_SDL_main_h
+
 flag example
   description: Build the example executable
   default:     False

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,7 @@
 resolver: lts-7.18
 system-ghc: true
+packages:
+- '.'
+- location:
+    git: https://github.com/haskell-game/sdl2.git
+    commit: 50fd095dcfdf64a8d43f2ac001da06b2665cec00


### PR DESCRIPTION
fixes #5 , same solution for the same problem with sdl2, sdl2-ttf, sdl2-mixer

Tested that this builds and runs correctly on 64-bit Windows 10 with stack resolvers:
- lts-8.13 (ghc 8.0.2)
- nightly-2017-07-31 (ghc 8.2.1)