### PR TITLE
Fix Windows 10 build error by defining SDL_MAIN_HANDLED macro

### DIFF
--- a/sdl2-image.cabal
+++ b/sdl2-image.cabal
@@ -43,7 +43,7 @@ library
     Haskell2010
 
   if os(windows)
-    cpp-options: -D_SDL_main_h -DSDL_main_h_
+    cpp-options: -D_SDL_main_h -DSDL_main_h_ -DSDL_MAIN_HANDLED
 
 flag example
   description: Build the example executable


### PR DESCRIPTION
The error message suggests that the `main` function gets `#define`d as `SDL_main`, according to the official documentation of SDL2, to avoid this behaviour, one can `#define SDL_MAIN_HANDLED` before `#include`ing the SDL headers.

Already tested on my Windows 10 machine, error no longer occurs.