### PR TITLE
Use th-abstraction to make GHC 9.0.1 compatible

### DIFF
--- a/sdl2-image.cabal
+++ b/sdl2-image.cabal
@@ -37,7 +37,8 @@ library
     bytestring       >= 0.10.4.0,
     sdl2             >= 2.0,
     text             >= 1.1.0.0,
-    template-haskell
+    template-haskell,
+    th-abstraction   >= 0.4.0.0
 
   default-language:
     Haskell2010

--- a/src/SDL/Raw/Helper.hs
+++ b/src/SDL/Raw/Helper.hs
@@ -17,9 +17,10 @@ inlined MonadIO variant. Use this to simplify the package's SDL.Raw.* modules.
 
 module SDL.Raw.Helper (liftF) where
 
-import Control.Monad           (replicateM)
-import Control.Monad.IO.Class  (MonadIO, liftIO)
+import Control.Monad                          (replicateM)
+import Control.Monad.IO.Class                 (MonadIO, liftIO)
 import Language.Haskell.TH
+import Language.Haskell.TH.Datatype.TyVarBndr (plainTVSpecified)
 
 -- | Given a name @fname@, a name of a C function @cname@ and the desired
 -- Haskell type @ftype@, this function generates:
@@ -81,7 +82,7 @@ liftType = \case
     m <- newName "m"
     return $
       ForallT
-        [PlainTV m]
+        [plainTVSpecified m]
         [AppT (ConT ''MonadIO) $ VarT m]
         (AppT (VarT m) t)
   t -> return t


### PR DESCRIPTION
Same idea as https://github.com/haskell-game/sdl2-ttf/commit/8d68a46424457477739bb7fbfc19de304c916171, tested building this successfully with GHC 8.10.7 and GHC 9.0.2.
EDIT: Would normally bump the patch version in the cabal file but not sure what the version system is for this library?